### PR TITLE
Fix docker build argument list

### DIFF
--- a/lib/cargolambda.js
+++ b/lib/cargolambda.js
@@ -79,6 +79,8 @@ function buildArgs(options) {
       '-w',
       '/tmp',
       DOCKER_IMAGE,
+      'cargo',
+      'lambda',
       'build',
       ...buildOptions,
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-rust-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-rust-plugin",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-rust-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Serverless Framework plugin for Rust using Cargo Lambda.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This command fails when I run it:
`docker run --rm -t -v $(pwd):/tmp -w /tmp calavera/cargo-lambda build --release --arm64`,

and this command succeeds:
`docker run --rm -t -v $(pwd):/tmp -w /tmp calavera/cargo-lambda cargo lambda build --release --arm64`.

I get the same result with Amazon's cargo-lambda Docker image: `ghcr.io/cargo-lambda/cargo-lambda`.