### PR TITLE
Update docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ custom:
 | option | path in serverless.yml | values | description |
 | :--- | :--- | :---: | :--- |
 | architecture | provider.architecture | x86_64, arm64 | The architecture cargo lambda compiles for. default is x86_64. |
-| docker | custom.rust.cargoLambda.docker | boolean | Use docker to compile or not. If true, this plugin uses [calavera/cargo-lambda](https://hub.docker.com/r/calavera/cargo-lambda) otherwise cargo lambda in your local machine. |
+| docker | custom.rust.cargoLambda.docker | boolean | Use docker to compile or not. If true, this plugin uses [cargo-lambda/cargo-lambda](https://github.com/cargo-lambda/cargo-lambda/pkgs/container/cargo-lambda) otherwise cargo lambda in your local machine. |
 | profile | custom.rust.cargoLambda.profile | release, debug | The mode cargo lambda compiles. default is release. |
 
 ### Local Test

--- a/lib/cargolambda.js
+++ b/lib/cargolambda.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const utils = require('./utils');
 
-const DOCKER_IMAGE = 'calavera/cargo-lambda:latest';
+const DOCKER_IMAGE = 'ghcr.io/cargo-lambda/cargo-lambda';
 
 class Artifacts {
   constructor(artifacts) {

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -45,7 +45,7 @@ async function invoke(invokeOptions) {
     // We have to retry in case of that.
     req.on('error', (err) => {
       if (retryCount === 0) {
-        reject(err);
+        return reject(err);
       }
 
       const retryOptions = {
@@ -53,7 +53,7 @@ async function invoke(invokeOptions) {
         retryCount: retryCount - 1,
       };
 
-      setTimeout(() => {
+      return setTimeout(() => {
         resolve(invoke(retryOptions));
       }, retryInterval);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-rust-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-rust-plugin",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-rust-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A Serverless Framework plugin for Rust using Cargo Lambda.",
   "main": "index.js",
   "scripts": {

--- a/tests/lib/cargolambda.test.js
+++ b/tests/lib/cargolambda.test.js
@@ -28,7 +28,7 @@ describe('CargoLambda', () => {
 
       it('with arguments for docker run if option docker is true', async () => {
         await subject({ docker: true, srcPath });
-        expect(utils.spawn.mock.lastCall[1]).toEqual(expect.arrayContaining([
+        expect(utils.spawn.mock.lastCall[1]).toEqual([
           'run',
           '--rm',
           '-t',
@@ -36,9 +36,11 @@ describe('CargoLambda', () => {
           'test/path:/tmp',
           '-w',
           '/tmp',
-          'calavera/cargo-lambda:latest',
+          'ghcr.io/cargo-lambda/cargo-lambda',
+          'cargo',
+          'lambda',
           'build',
-        ]));
+        ]);
       });
 
       it('with arguments for cargo lambda if option docker is false', async () => {


### PR DESCRIPTION
* update the docker image
This is the same image from the same owner (calavera). It seems he migrated to another registry.

* update/fix unit test for docker arguments
`arrayContaining()` only verifies a subset of list arguments, so unit tests didn't flag the added docker arguments.

* return when retryCount is 0 to fully exit the function
Jest flagged this with `--detectOpenHandles`, and unit tests now successfully shut down instead of hanging open.